### PR TITLE
Fix app import

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -11,14 +11,16 @@ require('./styles/app.styl');
 
 let Application = Mn.Application.extend({
 
-    _initChannel() {
+    _initChannel () {
         this.channelName = _.result(this, 'channelName') || 'global';
         this.channel = _.result(this, 'channel') || Radio.channel(this.channelName);
     },
 
-    initialize() {
+    initialize () {
         this.appState = new AppState();
+    },
 
+    onBeforeStart () {
         let allTracks = new Tracks([], { type: 'all' });
         allTracks.fetch({
             success() {
@@ -45,7 +47,7 @@ let Application = Mn.Application.extend({
         this.allPlaylists.fetch();
     },
 
-    onStart() {
+    onStart () {
         if (Backbone.history) {
             Backbone.history.start();
         }

--- a/app/collections/tracks.js
+++ b/app/collections/tracks.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import Track from '../models/track';
 import cozysdk from 'cozysdk-client';
-
+import application from '../application'
 
 const Tracks = Backbone.Collection.extend({
 
@@ -11,7 +11,6 @@ const Tracks = Backbone.Collection.extend({
         this.on('add', this.onAdd, this);
         this.type = options.type;
         if (this.type == 'upNext') {
-            let application = require('../application'); // Switch to System.import later
             this.listenTo(application, 'start', this.addCurrentToUpNext);
         }
     },
@@ -36,11 +35,11 @@ const Tracks = Backbone.Collection.extend({
             track.save();
         }
     },
-    
+
     comparator(model) {
         return model.get('metas').title;
     },
-    
+
     sync(method, model, options) {
         if (method == 'read' && this.type) {
             cozysdk.run('Track', this.type, {}, (err, res) => {


### PR DESCRIPTION
This PR fix the issue of importing app instance in deps during app construct. By using the `before:start` app event, it let application construct, and then call for init deps, which resolves the circular deps.
